### PR TITLE
Don't hard-code unnecessary things in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,21 +32,12 @@ MCL_LIB=../mcl/lib/libmcl.a
 $(MCL_LIB):
 	$(MAKE) -C ../mcl lib/libmcl.a
 
-ifeq ($(DOCKER),alpine)
-GMP_PREFIX?=/usr/lib
-OPENSSL_PREFIX?=/usr/lib
-else ifeq ($(OS),mac)
-GMP_PREFIX?=$(shell brew --prefix gmp)/lib
-OPENSSL_PREFIX?=$(shell brew --prefix openssl)/lib
-else
-GMP_PREFIX?=/usr/lib/x86_64-linux-gnu
-OPENSSL_PREFIX?=/usr/lib/x86_64-linux-gnu
-endif
+GMP_PREFIX=$(shell brew --prefix gmp)
+GMP_STATIC_LIB=$(GMP_PREFIX)/lib/libgmp.a
+GMPXX_STATIC_LIB=$(GMP_PREFIX)/lib/libgmpxx.a
 
-GMP_STATIC_LIB=$(GMP_PREFIX)/libgmp.a
-GMPXX_STATIC_LIB=$(GMP_PREFIX)/libgmpxx.a
-
-OPENSSL_STATIC_LIB=$(OPENSSL_PREFIX)/libcrypto.a
+OPENSSL_PREFIX=$(shell brew --prefix openssl)
+OPENSSL_STATIC_LIB="$(OPENSSL_PREFIX)/lib/libcrypto.a"
 
 $(BLS256_LIB): $(OBJ_DIR)/bls_c256.o
 	$(AR) $@ $<
@@ -59,7 +50,6 @@ $(BLS384_LIB): $(OBJ_DIR)/bls_c384.o $(MCL_LIB)
 		ar x $(GMP_STATIC_LIB) && \
 		ar x $(GMPXX_STATIC_LIB)
 	$(AR) $@ $< tmp/*.o
-	rm -rf tmp
 
 ifneq ($(findstring $(OS),mac/mingw64),)
   BLS256_SLIB_LDFLAGS+=-lgmpxx -lgmp -lcrypto -lstdc++

--- a/Makefile
+++ b/Makefile
@@ -32,24 +32,10 @@ MCL_LIB=../mcl/lib/libmcl.a
 $(MCL_LIB):
 	$(MAKE) -C ../mcl lib/libmcl.a
 
-GMP_PREFIX=$(shell brew --prefix gmp)
-GMP_STATIC_LIB=$(GMP_PREFIX)/lib/libgmp.a
-GMPXX_STATIC_LIB=$(GMP_PREFIX)/lib/libgmpxx.a
-
-OPENSSL_PREFIX=$(shell brew --prefix openssl)
-OPENSSL_STATIC_LIB="$(OPENSSL_PREFIX)/lib/libcrypto.a"
-
 $(BLS256_LIB): $(OBJ_DIR)/bls_c256.o
 	$(AR) $@ $<
 $(BLS384_LIB): $(OBJ_DIR)/bls_c384.o $(MCL_LIB)
-	rm -rf  tmp
-	mkdir -p tmp
-	cd tmp && \
-		ar x ../$(MCL_LIB) && \
-		ar x $(OPENSSL_STATIC_LIB) && \
-		ar x $(GMP_STATIC_LIB) && \
-		ar x $(GMPXX_STATIC_LIB)
-	$(AR) $@ $< tmp/*.o
+	$(AR) $@ $<
 
 ifneq ($(findstring $(OS),mac/mingw64),)
   BLS256_SLIB_LDFLAGS+=-lgmpxx -lgmp -lcrypto -lstdc++

--- a/ffi/go/bls/bls.go
+++ b/ffi/go/bls/bls.go
@@ -2,8 +2,10 @@ package bls
 
 /*
 #cgo CFLAGS:-I../../../include -I../../../../mcl/include/
-#cgo LDFLAGS:${SRCDIR}/../../../lib/libbls384.a -lstdc++
+#cgo LDFLAGS:${SRCDIR}/../../../lib/libbls384.a ${SRCDIR}/../../../../mcl/lib/libmcl.a -lgmpxx -lgmp
 #cgo CFLAGS:-DMCLBN_FP_UNIT_SIZE=6
+#cgo pkg-config: libcrypto
+#cgo static pkg-config: --static
 #include <bls/bls.h>
 */
 import "C"

--- a/ffi/go/bls/dummy.cpp
+++ b/ffi/go/bls/dummy.cpp
@@ -1,0 +1,3 @@
+// This is a dummy source file which forces cgo to use the C++ linker instead
+// of the default C linker. We can therefore eliminate non-portable linker
+// flags such as -lstdc++, which is likely to break on FreeBSD and OpenBSD.


### PR DESCRIPTION
Revert unnecessary Makefile changes

This reverts following commits:

84bc185fa7ec7c4039f31446c9c60ed54a5e3435
7cdcfda42e5a9fc5ac0c8b0f243b85f26c4df586
32fbf283dfdcf1224c57fbf7cf9db5f290cda1d1
8b3853095b5aa8fe2b6c098b15f1d6ed898fd3c1

These commits are mostly fixup changes of commit
9847ea001a57a95bac22527514929abcbdba4907 which introduce even more
workarounds and hard-coded values into Makefile.

Make static linking work on more platforms

This partially reverts commit 9847ea001a57a95bac22527514929abcbdba4907.

Instead of linking everything statically, which is hard to do correctly
without special support from the build system, we only links internal
libraries such as bls and mcl statically. External libraries such as
GMP and OpenSSL are linked with the default way of the linker, avoiding
hard-coding absolute paths in Makefile.

Repacking libbls384.a to include object files from other static
libraries is unlikely to work reliably. It is hard to find library files
on the system without a lot of platform-specific code. It is even harder
to know private dependencies of these libraries without the help of
pkg-config .pc files or libtool .la files.

However, GMP doesn't provide .pc files, so we still have to fallback to
using cgo LDFLAGS. Fortunately, GMP doesn't seem to have external
dependencies so the same flags can be used for both static and dynamic
linking. Note that the order of -lgmpxx and -lgmp is significant. gmpxx
depends on gmp so it has to be put before gmp in case of static linking.

Most OpenSSL installation provides .pc files, so cgo pkg-config is used
here. Since we only use the libcrypto part of OpenSSL, we tell
pkg-config to use libcrypto instead of openssl. A new build tag 'static'
is added to support static linking. It is not done by default to avoid
over-linking for dynamic linking.

The non-portable -lstdc++ flag is also removed. It is possible for
platforms using LLVM libc++ to not include libstdc++ in their systems.
Instead of manually adding standard C++ library to the linker command
line, it is better to use the C++ compiler to link. To ask cgo to use
the C++ compiler instead of the default behavior of using the C
compiler, an empty C++ source file is added to the Go package.